### PR TITLE
Update check.js

### DIFF
--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -88,7 +88,7 @@ var check = function check(task, _ref) {
   }).then(function () {
     return (0, _git2.default)('remote update basetheme', 'Updating basetheme remote', gopts);
   }).then(function () {
-    return (0, _git2.default)('merge-base master basetheme/master', 'Getting most recently merged basetheme commit', gopts);
+    return (0, _git2.default)('merge-base $(git rev-parse --abbrev-ref HEAD) basetheme/master', 'Getting most recently merged basetheme commit', gopts);
   }).catch(function () {
     if (!fallbackCommit) {
       throw new Error('Could not find a merge base with the base theme ' + 'repository, or a baseThemeVersion specified in ' + 'theme.json. Please check your `basetheme` remote, ' + 'or the `baseTheme` and `baseThemeVersion` properties ' + 'in your `theme.json` file.');


### PR DESCRIPTION
I updated to run git merge-base on the current git branch and the basetheme/master. When you are working in a branch (e.g. develop) this command keeps reverting basetheme commit and version in theme.json to previous basetheme versions and complaining that there is newer version available, even when theme.json points to the most recent basetheme version.
